### PR TITLE
Update dependencies and add Sync/Send marker traits to Polygon/Tristrip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ license = "MIT"
 lazy_static = "0.2"
 
 [build-dependencies]
-bindgen = "0.26"
-gcc = "0.3"
+bindgen = "0.49"
+cc = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,11 @@
 extern crate bindgen;
-extern crate gcc;
+extern crate cc;
 
 use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    gcc::Build::new().file("src/gpc.c").compile("gpc");
+    cc::Build::new().file("src/gpc.c").compile("gpc");
 
     let bindings = bindgen::Builder::default()
         .header("src/gpc.h")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,12 @@ impl Vertex {
 
 pub struct Polygon(gpc::gpc_polygon);
 
+// The library doesn't mind if the data migrates to another thread
+unsafe impl Send for Polygon {}
+
+// It's safe for multiple threads to share read-only access to the data
+unsafe impl Sync for Polygon {}
+
 impl Polygon {
     pub fn new() -> Polygon {
         Polygon(gpc::gpc_polygon {
@@ -164,6 +170,12 @@ impl<'a> Iterator for ContourVertices<'a> {
 }
 
 pub struct Tristrip(gpc::gpc_tristrip);
+
+// The library doesn't mind if the data migrates to another thread
+unsafe impl Send for Tristrip {}
+
+// It's safe for multiple threads to share read-only access to the data
+unsafe impl Sync for Tristrip {}
 
 impl Tristrip {
     pub fn new() -> Tristrip {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,10 +22,10 @@ pub enum ClipOperation {
 impl ClipOperation {
     fn into_gpc_op(self) -> gpc::gpc_op {
         match self {
-            ClipOperation::Difference => gpc::gpc_op::GPC_DIFF,
-            ClipOperation::Intersection => gpc::gpc_op::GPC_INT,
-            ClipOperation::ExclusiveOr => gpc::gpc_op::GPC_XOR,
-            ClipOperation::Union => gpc::gpc_op::GPC_UNION,
+            ClipOperation::Difference => gpc::gpc_op_GPC_DIFF,
+            ClipOperation::Intersection => gpc::gpc_op_GPC_INT,
+            ClipOperation::ExclusiveOr => gpc::gpc_op_GPC_XOR,
+            ClipOperation::Union => gpc::gpc_op_GPC_UNION,
         }
     }
 }


### PR DESCRIPTION
 - Updated to latest decencies to fix warning about deprecated gcc dependency
 - Added Sync/Send marker traits to Polygon/Tristrip